### PR TITLE
Additional fixes as part of actor-interfaces PR #40

### DIFF
--- a/src/rust/host_visitor.ts
+++ b/src/rust/host_visitor.ts
@@ -55,7 +55,7 @@ pub struct ${className} {
     }
     const operation = context.operation!;
     this.write(formatComment("  /// ", operation.description));
-    this.write(`\npub fn ${functionName(operation.name.value)}(&self`);
+    this.write(`pub fn ${functionName(operation.name.value)}(&self`);
     operation.arguments.map((arg, index) => {
       this.write(
         `, ${fieldName(arg.name.value)}: ${expandType(
@@ -117,11 +117,11 @@ pub struct ${className} {
     if (!retVoid) {
       this.write(`.map(|vec| {
         let resp = deserialize::<${expandType(
-          operation.type,
-          undefined,
-          true,
-          isReference(operation.annotations)
-        )}>(vec.as_ref()).unwrap();
+        operation.type,
+        undefined,
+        true,
+        isReference(operation.annotations)
+      )}>(vec.as_ref()).unwrap();
         resp
       })\n`);
     } else {

--- a/src/rust/module_visitor.ts
+++ b/src/rust/module_visitor.ts
@@ -72,12 +72,7 @@ use std::io::Cursor;
 #[cfg(feature = "guest")]
 extern crate wapc_guest as guest;
 #[cfg(feature = "guest")]
-use guest::prelude::*;
-
-#[cfg(feature = "guest")]
-use lazy_static::lazy_static;
-#[cfg(feature = "guest")]
-use std::sync::RwLock;\n\n`);
+use guest::prelude::*;\n\n`);
     super.triggerDocumentBefore(context);
   }
 

--- a/src/rust/wrappers_visitor.ts
+++ b/src/rust/wrappers_visitor.ts
@@ -20,14 +20,14 @@ export class WrapperVarsVisitor extends BaseVisitor {
     }
     if (context.config.handlerPreamble != true) {
       this.write(`#[cfg(feature = "guest")]
-lazy_static! {\n`);
+lazy_static::lazy_static! {\n`);
       context.config.handlerPreamble = true;
     }
     const operation = context.operation!;
     this.write(
       `static ref ${functionName(
         operation.name.value
-      ).toUpperCase()}: RwLock<Option<fn(`
+      ).toUpperCase()}: std::sync::RwLock<Option<fn(`
     );
     operation.arguments.forEach((arg, i) => {
       if (i > 0) {
@@ -50,7 +50,7 @@ lazy_static! {\n`);
     } else {
       this.write(`()`);
     }
-    this.write(`>>> = RwLock::new(None);\n`);
+    this.write(`>>> = std::sync::RwLock::new(None);\n`);
   }
 
   visitAllOperationsAfter(context: Context): void {


### PR DESCRIPTION
So far I've implemented a few fixes to the codegen (Draft PR for now):
1. Removed newline before function definitions, created a space between doc comment and function
1. Removed the lazy static and RwLock import from the top of the file in favor of using the absolute crate reference. This allows generated files that don't have any handlers to avoid the unused linter warnings for those two crates.