### PR TITLE
Fixed a serialize unnecessary result

### DIFF
--- a/src/rust/wrappers_visitor.ts
+++ b/src/rust/wrappers_visitor.ts
@@ -99,7 +99,7 @@ fn ${functionName(
         `let result = lock(${varAccessArg("input", operation.arguments)})?;\n`
       );
     }
-    this.write(`Ok(serialize(result)?)\n`);
+    this.write(`serialize(result)\n`);
     this.write(`}\n\n`);
   }
 


### PR DESCRIPTION
Since `serialize(result)` already returns a Result, unwrapping it with `?` and wrapping it with `Ok()` is unnecessary. This doesn't change any functionality, but this saves us an unwrap operation and clippy doesn't get upset about it anymore.

I generated a few interfaces with this on the `codegen_roles` PR and it all works fine 😄 