### PR TITLE
Restored optionals in host_visitor function parameters

### DIFF
--- a/src/assemblyscript/host_visitor.ts
+++ b/src/assemblyscript/host_visitor.ts
@@ -40,7 +40,7 @@ export class HostVisitor extends BaseVisitor {
         this.write(`, `);
       }
       this.write(
-        `${param.name.value}: ${expandType(param.type, false, false)}`
+        `${param.name.value}: ${expandType(param.type, true, false)}`
       );
     });
     this.write(`): ${expandType(operation.type, true, false)} {\n`);
@@ -64,8 +64,7 @@ export class HostVisitor extends BaseVisitor {
       this.write(
         `hostCall(this.binding, ${strQuote(
           context.namespace.name.value
-        )}, ${strQuote(operation.name.value)}, ${
-          operation.unaryOp().name.value
+        )}, ${strQuote(operation.name.value)}, ${operation.unaryOp().name.value
         }.toBuffer());\n`
       );
     } else {

--- a/src/go/host_visitor.ts
+++ b/src/go/host_visitor.ts
@@ -44,7 +44,7 @@ export class HostVisitor extends BaseVisitor {
         `, ${param.name.value} ${expandType(
           param.type,
           undefined,
-          false,
+          true,
           false
         )}`
       );
@@ -72,9 +72,8 @@ export class HostVisitor extends BaseVisitor {
       );
     }
     if (operation.isUnary()) {
-      this.write(`inputPayload, err := msgpack.Marshal(${
-        operation.parameters[0].type.isKind(Kind.Optional) ? "" : "&"
-      }${operation.parameters[0].name.value})
+      this.write(`inputPayload, err := msgpack.Marshal(${operation.parameters[0].type.isKind(Kind.Optional) ? "" : "&"
+        }${operation.parameters[0].name.value})
       if err != nil {
         return ret, err
       }\n`);

--- a/src/rust/host_visitor.ts
+++ b/src/rust/host_visitor.ts
@@ -61,7 +61,7 @@ pub struct ${className} {
         `, ${fieldName(param.name.value)}: ${expandType(
           param.type,
           undefined,
-          false,
+          true,
           false
         )}`
       );
@@ -117,11 +117,11 @@ pub struct ${className} {
     if (!retVoid) {
       this.write(`.map(|vec| {
         let resp = deserialize::<${expandType(
-          operation.type,
-          undefined,
-          true,
-          isReference(operation.annotations)
-        )}>(vec.as_ref()).unwrap();
+        operation.type,
+        undefined,
+        true,
+        isReference(operation.annotations)
+      )}>(vec.as_ref()).unwrap();
         resp
       })\n`);
     } else {


### PR DESCRIPTION
In the `host_visitor` class of all three languages, the parameter expand type operation did not respect optional values.