### PR TITLE
fix(rust): Args struct not generated for function that takes no args

### DIFF
--- a/src/rust/module_visitor.ts
+++ b/src/rust/module_visitor.ts
@@ -49,7 +49,7 @@ export class ModuleVisitor extends BaseVisitor {
       "arguments",
       (context: Context): void => {
         const operation = context.operation!;
-        if (operation.parameters.length == 0 || operation.isUnary()) {
+        if (operation.isUnary()) {
           return;
         }
         const type = this.convertOperationToType(operation);


### PR DESCRIPTION
# DISCLAIMER
I did not test that fix. I could if someone provides guidance

## Steps to reproduce bug:
```bash
wapc new rust bug-poc
vim schema.widl # edit schema.widl as given below
```
```
namespace "greeting"

interface {
  sayHello(): string
}
```
```bash
make codegen build
```

Closes #12